### PR TITLE
Fix breaking changes for style-dictionary v4.x.x

### DIFF
--- a/build/BuildSystem/StyleDictionary.csx
+++ b/build/BuildSystem/StyleDictionary.csx
@@ -8,8 +8,7 @@ public static class StyleDictionary
 {
     public static Task Build(string configPath)
     {
-    
-        return Command.ExecuteAsync($"npx", $"style-dictionary build", configPath);
+        return Command.ExecuteAsync($"npx", $"style-dictionary build", configPath, verbose: true);
     }
     /// <summary>
     /// Get the config file from style dictionary root folder

--- a/build/bootstrapper/bootstrapper.sh
+++ b/build/bootstrapper/bootstrapper.sh
@@ -13,6 +13,8 @@ fi
 
 if npm list --prefix ./src | grep style-dictionary > /dev/null ; then
    echo "✅ npm package: style-dictionary was found"
+   echo "style-dictionary version: $(npm view style-dictionary version)"
 else
    npm install --prefix ./src style-dictionary
+   echo "style-dictionary version: $(npm view style-dictionary version)"
 fi

--- a/src/config.json
+++ b/src/config.json
@@ -14,7 +14,7 @@
             ]
         },
         "raw": {
-            "transforms": ["attribute/cti", "name/cti/kebab"],
+            "transforms": ["attribute/cti", "name/kebab"],
             "buildPath": "../output/raw/",
             "files": [
                 {


### PR DESCRIPTION
Changes accoriding to [Migration Guidelines - CTI Reliance](https://v4.styledictionary.com/version-4/migration/#cti-reliance) has been made, and also added verbose print to the method executing the style-dictionary command. In addition, the bootstrapper will print the version of style-dictionary.